### PR TITLE
Pass body to checkAccess

### DIFF
--- a/src/endpoints/stream.ts
+++ b/src/endpoints/stream.ts
@@ -48,7 +48,7 @@ export function getStreamEndpoints(config: NormalizedBunnyStorageConfig): Endpoi
 
           let accessResult = true
           if (stream.tus?.checkAccess) {
-            accessResult = await stream.tus.checkAccess(req)
+            accessResult = await stream.tus.checkAccess(req,body)
           } else {
             const accessResults = await getAccessResults({ req })
             accessResult = false

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -2,6 +2,7 @@ import type { MediaPreviewProps } from '@/fields/index.js'
 import type { CollectionOptions } from '@payloadcms/plugin-cloud-storage/types'
 import type { AcceptedLanguages } from '@payloadcms/translations'
 import type { CollectionConfig, PayloadRequest, Plugin, TaskConfig, UploadCollectionSlug } from 'payload'
+import type { StreamTusAuthRequest } from './core.js'
 
 export type UrlTransformFunction = (args: {
   /** Base URL */
@@ -135,7 +136,7 @@ export type StreamTusConfig = {
      * By default, checks if user has admin access and create access to at least one collection
      * configured in the plugin.
      */
-  checkAccess?: (req: PayloadRequest) => boolean | Promise<boolean>
+  checkAccess?: (req: PayloadRequest,body:StreamTusAuthRequest) => boolean | Promise<boolean>
   /**
      * @deprecated Use stream.mimeTypes instead. This option will be removed in v2.3.0.
      * Video and audio file types allowed for TUS uploads.


### PR DESCRIPTION
I have a multi Tennant app and want to check the file size before the upload.
Passing the body to the checkAccess function seems most straightforward way.
